### PR TITLE
Add: confirmation before delete passwords

### DIFF
--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -63,7 +63,7 @@
 	$appPassTbody.on( 'click', '.delete', function( e ) {
 		e.preventDefault();
 
-		if ( ! confirm( appPass.revoke_password ) ) {
+		if ( ! confirm( wp.i18n.__( 'Are you sure you want to revoke this password? This action cannot be undone.' ) ) ) {
 			return;
 		}
 
@@ -92,7 +92,7 @@
 	$removeAllBtn.on( 'click', function( e ) {
 		e.preventDefault();
 
-		if ( ! confirm( appPass.revoke_all_passwords ) ) {
+		if ( ! confirm( wp.i18n.__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ) ) ) {
 			return;
 		}
 

--- a/src/js/_enqueues/admin/application-passwords.js
+++ b/src/js/_enqueues/admin/application-passwords.js
@@ -62,6 +62,11 @@
 
 	$appPassTbody.on( 'click', '.delete', function( e ) {
 		e.preventDefault();
+
+		if ( ! confirm( appPass.revoke_password ) ) {
+			return;
+		}
+
 		var $submitButton = $( this ),
 			$tr = $submitButton.closest( 'tr' ),
 			uuid = $tr.data( 'uuid' );
@@ -86,6 +91,11 @@
 
 	$removeAllBtn.on( 'click', function( e ) {
 		e.preventDefault();
+
+		if ( ! confirm( appPass.revoke_all_passwords ) ) {
+			return;
+		}
+
 		var $submitButton = $( this );
 
 		clearErrors();

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -29,14 +29,6 @@ wp_enqueue_script( 'user-profile' );
 
 if ( wp_is_application_passwords_available_for_user( $user_id ) ) {
 	wp_enqueue_script( 'application-passwords' );
-	wp_localize_script(
-		'application-passwords',
-		'appPass',
-		array(
-			'revoke_password'      => esc_attr__( 'Are you sure you want to revoke this password? This action cannot be undone.' ),
-			'revoke_all_passwords' => esc_attr__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ),
-		)
-	);
 }
 
 if ( IS_PROFILE_PAGE ) {

--- a/src/wp-admin/user-edit.php
+++ b/src/wp-admin/user-edit.php
@@ -29,6 +29,14 @@ wp_enqueue_script( 'user-profile' );
 
 if ( wp_is_application_passwords_available_for_user( $user_id ) ) {
 	wp_enqueue_script( 'application-passwords' );
+	wp_localize_script(
+		'application-passwords',
+		'appPass',
+		array(
+			'revoke_password'      => esc_attr__( 'Are you sure you want to revoke this password? This action cannot be undone.' ),
+			'revoke_all_passwords' => esc_attr__( 'Are you sure you want to revoke all passwords? This action cannot be undone.' ),
+		)
+	);
 }
 
 if ( IS_PROFILE_PAGE ) {
@@ -707,7 +715,7 @@ endif;
 	</table>
 
 
-		<?php if ( wp_is_application_passwords_available_for_user( $user_id ) ) : ?>
+<?php if ( wp_is_application_passwords_available_for_user( $user_id ) ) : ?>
 	<div class="application-passwords hide-if-no-js" id="application-passwords-section">
 		<h2><?php _e( 'Application Passwords' ); ?></h2>
 		<p><?php _e( 'Application passwords allow authentication via non-interactive systems, such as XMLRPC or the REST API, without providing your actual password. Application passwords can be easily revoked. They cannot be used for traditional logins to your website.' ); ?></p>


### PR DESCRIPTION
This PR adds a confirmation box when users click on revoke password buttons.

From: https://github.com/WordPress/application-passwords/pull/119